### PR TITLE
fix ssd1306_set_pixel with flip_enabled

### DIFF
--- a/components/peripherals/i2c/esp_ssd1306/ssd1306.c
+++ b/components/peripherals/i2c/esp_ssd1306/ssd1306.c
@@ -356,13 +356,13 @@ esp_err_t ssd1306_set_pixel(ssd1306_handle_t handle, uint8_t xpos, uint8_t ypos,
 
 	ESP_LOGD(TAG, "ypos=%d _page=%d _bits=%d wk0=0x%02x wk1=0x%02x", ypos, _page, _bits, wk0, wk1);
 
+	if (dev->config.flip_enabled) wk1 = ssd1306_rotate_byte(wk1);
+
 	if (invert) {
 		wk0 = wk0 & ~wk1;
 	} else {
 		wk0 = wk0 | wk1;
 	}
-
-	if (dev->config.flip_enabled) wk0 = ssd1306_rotate_byte(wk0);
 
 	ESP_LOGD(TAG, "wk0=0x%02x wk1=0x%02x", wk0, wk1);
 


### PR DESCRIPTION
If flip_enadled == true - don't rotate bytes from screen memory (coz multiple rotations appear) but byte to set.